### PR TITLE
Add distributionSha256Sum to Gradle wrapper

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -4,3 +4,4 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionSha256Sum=5c07b3bac2209fbc98fb1fdf6fd831f72429cdf8c503807404eae03d8c8099e5


### PR DESCRIPTION
This patch adds the `distributionSha256Sum` property that allows gradlew to verify the Gradle binary it downloads.
You can find more information about this here: https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:verification