### PR TITLE
Fix gradlew error about mismatching SHA256 sum

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -4,4 +4,4 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
-distributionSha256Sum=5c07b3bac2209fbc98fb1fdf6fd831f72429cdf8c503807404eae03d8c8099e5
+distributionSha256Sum=14cd15fc8cc8705bd69dcfa3c8fefb27eb7027f5de4b47a8b279218f76895a91


### PR DESCRIPTION
Gradlew build throws error about mismatching SHA256 sum when downloading gradle complete. The previous SHA256 was for v4.1, not v5.4.1.

List here: https://gradle.org/release-checksums/